### PR TITLE
feat(shutdown-handle): Return `TracingShutdownHandle` from battery initialization.

### DIFF
--- a/examples/datadog.rs
+++ b/examples/datadog.rs
@@ -5,7 +5,8 @@ pub const SERVICE_NAME: &str = "datadog-example";
 
 pub fn main() -> eyre::Result<()> {
     // Add a new DatadogBattery for tracing/logs
-    DatadogBattery::init(None, SERVICE_NAME, None, true);
+    // Tracing providers are gracefully shutdown when shutdown handle is dropped.
+    let _shutdown_handle = DatadogBattery::init(None, SERVICE_NAME, None, true);
 
     // Add a new StatsdBattery for metrics
     StatsdBattery::init("localhost", 8125, 5000, 1024, None)?;
@@ -16,6 +17,5 @@ pub fn main() -> eyre::Result<()> {
     tracing::info!("foo");
     metrics::counter!("foo").increment(1);
 
-    // Tracing providers are shutdown at the end of the program when TRACING_PROVIDER_GUARD is dropped.
     Ok(())
 }

--- a/src/tracing/datadog.rs
+++ b/src/tracing/datadog.rs
@@ -6,6 +6,8 @@ use tracing_subscriber::{
     layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer,
 };
 
+use super::TracingShutdownHandle;
+
 pub const DEFAULT_DATADOG_AGENT_ENDPOINT: &str = "http://localhost:8126";
 
 pub struct DatadogBattery;
@@ -16,7 +18,7 @@ impl DatadogBattery {
         service_name: &str,
         file_appender: Option<RollingFileAppender>,
         location: bool,
-    ) {
+    ) -> TracingShutdownHandle {
         let endpoint = endpoint.unwrap_or(DEFAULT_DATADOG_AGENT_ENDPOINT);
 
         let datadog_layer = datadog_layer(service_name, endpoint, location);
@@ -33,5 +35,7 @@ impl DatadogBattery {
             let layers = EnvFilter::from_default_env().and_then(datadog_layer);
             tracing_subscriber::registry().with(layers).init();
         }
+
+        TracingShutdownHandle
     }
 }

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -11,11 +11,13 @@ use tracing_subscriber::fmt::{FmtContext, FormatFields};
 use tracing_subscriber::registry::{LookupSpan, SpanRef};
 pub use tracing_subscriber::Registry;
 
-pub static TRACING_PROVIDER_GUARD: TracingProviderGuard = TracingProviderGuard;
+/// `TracingShutdownHandle` ensures the global tracing provider
+/// is gracefully shut down when the handle is dropped, preventing loss
+/// of any remaining traces not yet exported.
+#[must_use]
+pub struct TracingShutdownHandle;
 
-pub struct TracingProviderGuard;
-
-impl Drop for TracingProviderGuard {
+impl Drop for TracingShutdownHandle {
     fn drop(&mut self) {
         tracing::warn!("Shutting down tracing provider");
         opentelemetry::global::shutdown_tracer_provider();

--- a/src/tracing/stdout.rs
+++ b/src/tracing/stdout.rs
@@ -1,4 +1,5 @@
 use crate::tracing::layers::stdout::stdout_layer;
+use crate::tracing::TracingShutdownHandle;
 use tracing_subscriber::{
     layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer,
 };
@@ -6,10 +7,12 @@ use tracing_subscriber::{
 pub struct StdoutBattery;
 
 impl StdoutBattery {
-    pub fn init() {
+    pub fn init() -> TracingShutdownHandle {
         let stdout_layer = stdout_layer();
         let layers = EnvFilter::from_default_env().and_then(stdout_layer);
         tracing_subscriber::registry().with(layers).init();
+
+        TracingShutdownHandle
     }
 }
 
@@ -23,7 +26,7 @@ mod tests {
     #[tokio::test]
     async fn test_init() {
         env::set_var("RUST_LOG", "info");
-        StdoutBattery::init();
+        let _shutdown_handle = StdoutBattery::init();
 
         for _ in 0..1000 {
             let span = tracing::span!(tracing::Level::INFO, "test_span");


### PR DESCRIPTION
This PR introduces logic to return `TracingShutdownHandle` from `Battery::init`, which will clean up the tracing provider when dropped.