### PR TITLE
Add OpenSSL license to deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -30,6 +30,7 @@ allow = [
     "LicenseRef-ring",
     "MIT",
     "MPL-2.0", # Although this is copyleft, it is scoped to modifying the original files
+    "OpenSSL",
     "Unicode-DFS-2016",
     "Unlicense",
     "Zlib",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

CI on `main` fails.

## Solution
Add `OpenSSL` license to cargo-deny's deny.toml

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
