### PR TITLE
reexport opentelemetry crate

### DIFF
--- a/telemetry-batteries/src/lib.rs
+++ b/telemetry-batteries/src/lib.rs
@@ -1,2 +1,11 @@
 pub mod metrics;
 pub mod tracing;
+
+/// Reexports of crates that appear in the public API.
+///
+/// Using these directly instead of adding them yourself to Cargo.toml will help avoid
+/// errors where types have the same name but actually are distinct types from different
+/// crate versions.
+pub mod reexports {
+    pub use ::opentelemetry;
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Right now, iris-mpc gets the following error when trying to update to the latest version of telemetry-batteries:
```
     Checking iris-mpc-common v0.1.0 (/Users/ryan.butler/P/wc/iris-mpc/iris-mpc-common)
error[E0308]: mismatched types
   --> iris-mpc-common/src/helpers/aws.rs:65:58
    |
65  | ...   telemetry_batteries::tracing::trace_from_ctx(parent_ct...
    |       -------------------------------------------- ^^^^^^^^^^ expected `SpanContext`, found a different `SpanContext`
    |       |
    |       arguments to this function are incorrect
    |
    = note: `SpanContext` and `SpanContext` have similar names, but are actually distinct types
note: `SpanContext` is defined in crate `opentelemetry`
   --> /Users/ryan.butler/.cargo/registry/src/index.crates.io-6f17d22bba15001f/opentelemetry-0.21.0/src/trace/span_context.rs:462:1
    |
462 | pub struct SpanContext {
    | ^^^^^^^^^^^^^^^^^^^^^^
note: `SpanContext` is defined in crate `opentelemetry`
   --> /Users/ryan.butler/.cargo/registry/src/index.crates.io-6f17d22bba15001f/opentelemetry-0.24.0/src/trace/span_context.rs:462:1
    |
462 | pub struct SpanContext {
    | ^^^^^^^^^^^^^^^^^^^^^^
    = note: perhaps two different versions of crate `opentelemetry` are being used?
note: function defined here
   --> /Users/ryan.butler/.cargo/git/checkouts/telemetry-batteries-454e0e325dce477c/35202f9/telemetry-batteries/src/tracing/mod.rs:108:8
    |
108 | pub fn trace_from_ctx(ctx: SpanContext) {
    |        ^^^^^^^^^^^^^^
                                                               
For more information about this error, try `rustc --explain E0308`.
error: could not compile `iris-mpc-common` (lib) due to 1 previous error

```

This occurs the version of `opentelemetry` is v0.24.0 in `telemetry-batteries`  but `iris-mpc-common` uses v0.21.0

## Solution

Re-export the `opentelemetry` crate. In general all fast moving crates that appear in public APIs should be exported. This will allow `iris-mpc-common` to track the same otel version that `telemetry-batteries` uses without having to manually ensure the version match by repeating the dependency.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
