### PR TITLE
Create features for metrics dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # telemetry-batteries
+
 Batteries included library to configure tracing, logs and metrics
 
 ## License

--- a/deny.toml
+++ b/deny.toml
@@ -4,7 +4,7 @@ all-features = true
 
 [advisories]
 version = 2
-ignore = []
+ignore = ["RUSTSEC-2024-0436"]
 
 [sources]
 unknown-registry = "deny"

--- a/telemetry-batteries/Cargo.toml
+++ b/telemetry-batteries/Cargo.toml
@@ -7,13 +7,18 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[features]
+default = ["metrics-prometheus", "metrics-statsd"]
+metrics-statsd = ["dep:metrics-exporter-statsd"]
+metrics-prometheus = ["dep:metrics-exporter-prometheus"]
+
 [dependencies]
 chrono = "0.4.31"
 dirs = "5.0.1"
 http = "1.1.0"
 metrics = "0.24"
-metrics-exporter-statsd = "0.9"
-metrics-exporter-prometheus = "0.16"
+metrics-exporter-statsd = { version = "0.9", optional = true }
+metrics-exporter-prometheus = { version = "0.16", optional = true }
 opentelemetry = { version = "0.26.0" }
 opentelemetry-datadog = { version = "0.14.0", features = ["reqwest-client"] }
 opentelemetry-http = "0.26"
@@ -22,7 +27,7 @@ reqwest = "0.12.8"
 serde = { version = "1.0.189", features = ["derive"] }
 serde_json = "1.0.108"
 thiserror = "2"
-tokio = "1.33.0"
+tokio = { version = "1.44.1", features = ["macros"] }
 tracing = "0.1.40"
 tracing-appender = "0.2.2"
 tracing-opentelemetry = "0.27"

--- a/telemetry-batteries/src/lib.rs
+++ b/telemetry-batteries/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(any(feature = "metrics-prometheus", feature = "metrics-statsd"))]
 pub mod metrics;
 pub mod tracing;
 
@@ -7,6 +8,10 @@ pub mod tracing;
 /// errors where types have the same name but actually are distinct types from different
 /// crate versions.
 pub mod reexports {
+    #[cfg(any(
+        feature = "metrics-prometheus",
+        feature = "metrics-statsd"
+    ))]
     pub use ::metrics;
     pub use ::opentelemetry;
 }

--- a/telemetry-batteries/src/metrics/mod.rs
+++ b/telemetry-batteries/src/metrics/mod.rs
@@ -1,2 +1,5 @@
+#[cfg(feature = "metrics-prometheus")]
 pub mod prometheus;
+
+#[cfg(feature = "metrics-statsd")]
 pub mod statsd;

--- a/telemetry-batteries/src/tracing/mod.rs
+++ b/telemetry-batteries/src/tracing/mod.rs
@@ -150,11 +150,9 @@ impl io::Write for WriteAdapter<'_> {
         let s = std::str::from_utf8(buf)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
-        self.fmt_write
-            .write_str(s)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        self.fmt_write.write_str(s).map_err(io::Error::other)?;
 
-        Ok(s.as_bytes().len())
+        Ok(s.len())
     }
 
     fn flush(&mut self) -> io::Result<()> {


### PR DESCRIPTION
## Motivation

The metrics-exporter-prometheus dependency brings in transient cryptographic dependencies which the application may not be setup to properly initialize. Bringing in telemetry-batteries can break such applications.

## Solution

Add cargo features to allow selection of the metrics dependencies, including prometheus.
Add default features to remain compatible with existing implementations.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Breaking changes
