### PR TITLE
feat: default to rustls for reqwest

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -25,8 +25,8 @@ allow = [
     "BSD-3-Clause",
     "BSL-1.0",
     "CC0-1.0",
+    "CDLA-Permissive-2.0",
     "ISC",
-    "LicenseRef-ring",
     "MIT",
     "MPL-2.0",                        # Although this is copyleft, it is scoped to modifying the original files
     "OpenSSL",
@@ -35,9 +35,3 @@ allow = [
     "Zlib",
     "Unicode-3.0",
 ]
-
-# See https://github.com/briansmith/ring/blob/95948b3977013aed16db92ae32e6b8384496a740/deny.toml#L12
-[[licenses.clarify]]
-name = "ring"
-expression = "LicenseRef-ring"
-license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]

--- a/telemetry-batteries/Cargo.toml
+++ b/telemetry-batteries/Cargo.toml
@@ -8,32 +8,38 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-default = ["metrics-prometheus", "metrics-statsd"]
+default = ["metrics-prometheus", "metrics-statsd", "rustls"]
 metrics-statsd = ["dep:metrics-exporter-statsd"]
 metrics-prometheus = ["dep:metrics-exporter-prometheus"]
+rustls = [
+    "reqwest/rustls-tls"
+]
+native-tls = [
+    "reqwest/native-tls"
+]
 
 [dependencies]
-chrono = "0.4.31"
-dirs = "5.0.1"
-http = "1.1.0"
+chrono = "0.4"
+dirs = "5"
+http = "1"
 metrics = "0.24"
 metrics-exporter-statsd = { version = "0.9", optional = true }
 metrics-exporter-prometheus = { version = "0.16", optional = true }
-opentelemetry = { version = "0.26.0" }
-opentelemetry-datadog = { version = "0.14.0", features = ["reqwest-client"] }
+opentelemetry = { version = "0.26" }
+opentelemetry-datadog = { version = "0.14", features = ["reqwest-client"] }
 opentelemetry-http = "0.26"
 opentelemetry_sdk = { version = "0.26", features = ["rt-tokio"] }
-reqwest = "0.12.8"
-serde = { version = "1.0.189", features = ["derive"] }
-serde_json = "1.0.108"
+reqwest = { version = "0.12", default-features = false }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 thiserror = "2"
-tokio = { version = "1.44.1", features = ["macros"] }
-tracing = "0.1.40"
-tracing-appender = "0.2.2"
+tokio = { version = "1", features = ["macros"] }
+tracing = "0.1"
+tracing-appender = "0.2"
 tracing-opentelemetry = "0.27"
-tracing-serde = "0.1.3"
-tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json"] }
-rand = "0.8.5"
+tracing-serde = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+rand = "0.8"
 
 [dev-dependencies]
-eyre = "0.6.9"
+eyre = "0.6"

--- a/telemetry-batteries/Cargo.toml
+++ b/telemetry-batteries/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telemetry-batteries"
-version = "0.1.0"
+version = "0.1.1"
 publish = false
 
 edition.workspace = true

--- a/telemetry-batteries/Cargo.toml
+++ b/telemetry-batteries/Cargo.toml
@@ -11,12 +11,8 @@ repository.workspace = true
 default = ["metrics-prometheus", "metrics-statsd", "rustls"]
 metrics-statsd = ["dep:metrics-exporter-statsd"]
 metrics-prometheus = ["dep:metrics-exporter-prometheus"]
-rustls = [
-    "reqwest/rustls-tls"
-]
-native-tls = [
-    "reqwest/native-tls"
-]
+rustls = ["reqwest/rustls-tls"]
+native-tls = ["reqwest/native-tls"]
 
 [dependencies]
 chrono = "0.4"

--- a/telemetry-batteries/build.rs
+++ b/telemetry-batteries/build.rs
@@ -1,0 +1,15 @@
+fn main() {
+    // Ensure exactly one TLS backend is enabled
+    let rustls = cfg!(feature = "rustls");
+    let native_tls = cfg!(feature = "native-tls");
+
+    match (rustls, native_tls) {
+        (false, false) => {
+            panic!("At least one TLS feature must be enabled: 'rustls' or 'native-tls'");
+        }
+        (true, true) => {
+            panic!("Only one TLS feature can be enabled at a time: 'rustls' or 'native-tls'");
+        }
+        _ => {}
+    }
+}

--- a/telemetry-batteries/build.rs
+++ b/telemetry-batteries/build.rs
@@ -1,15 +1,9 @@
 fn main() {
-    // Ensure exactly one TLS backend is enabled
+    // Ensure a TLS backend is enabled
     let rustls = cfg!(feature = "rustls");
     let native_tls = cfg!(feature = "native-tls");
 
-    match (rustls, native_tls) {
-        (false, false) => {
-            panic!("At least one TLS feature must be enabled: 'rustls' or 'native-tls'");
-        }
-        (true, true) => {
-            panic!("Only one TLS feature can be enabled at a time: 'rustls' or 'native-tls'");
-        }
-        _ => {}
+    if !rustls && !native_tls {
+        panic!("At least one TLS feature must be enabled: 'rustls' or 'native-tls'");
     }
 }

--- a/telemetry-batteries/src/tracing/layers/datadog.rs
+++ b/telemetry-batteries/src/tracing/layers/datadog.rs
@@ -113,7 +113,7 @@ where
             }
 
             if let Some(span_id) = span_id {
-                let span_id = format!("{}", span_id);
+                let span_id = format!("{span_id}");
                 serializer.serialize_entry("dd.span_id", &span_id)?;
             }
 


### PR DESCRIPTION
### Changes
- Defaults to using native rustls for TLS connectivity (by default no openssl needed).
- Allows using native-tls through a feature flag instead.
- Relax dependencies to allow upstream crates to select their own versions
- Bumps package version