### PR TITLE
Bump OpenTelemetry version and re-export it for downstream consumers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telemetry-batteries"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 description = "Batteries included library to configure tracing, logs and metrics"
 license = "MIT OR (Apache-2.0 WITH LLVM-exception)"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,11 @@ pub use config::{
 };
 pub use guard::TelemetryGuard;
 
+// Re-export core telemetry crates so downstream consumers use the same
+// version as telemetry-batteries, preventing duplicate-version conflicts.
+pub use opentelemetry;
+pub use tracing_opentelemetry;
+
 /// Reexports of crates that appear in the public API.
 ///
 /// Using these directly instead of adding them yourself to Cargo.toml will help avoid


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Re-export opentelemetry and tracing_opentelemetry at the crate root so downstream consumers can use              
  telemetry_batteries::opentelemetry::... instead of adding direct dependencies. This prevents duplicate crate
  versions in the dependency tree, which caused a BatchSpanProcessor/tokio deadlock in production (FM-810).  


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
