### PR TITLE
Remove tracing-error dependency due to tracing issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 tower = "0.5"
 tracing = "0.1"
 tracing-appender = "0.2"
-tracing-error = "0.2"
 tracing-opentelemetry = "0.32"
 tracing-serde = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/src/eyre/json_eyre.rs
+++ b/src/eyre/json_eyre.rs
@@ -5,29 +5,25 @@
 //! ```json
 //! {
 //!   "error_chain": [[0, "message"], [1, "cause"], ...],
-//!   "backtrace": [[0, {"function": "...", "file": "...", "line": 42}], ...],
-//!   "spantrace": [[0, {"full_name": "...", "file": "...", "line": 42, "fields": "key1=value1 key2=value2 ..."}], ...]
+//!   "backtrace": [[0, {"function": "...", "file": "...", "line": 42}], ...]
 //! }
 //! ```
 //!
 //! - `error_chain`: Indexed error messages, last element is root cause
 //! - `backtrace`: Optional, omitted if backtrace capture is disabled. Uses the backtrace crate to capture the backtrace.
-//! - `spantrace`: Optional, omitted if spantrace capture is disabled. Uses the tracing-error crate to capture the spantrace.
 
 use std::{env, iter::successors};
 
 use eyre::{EyreHandler, Report, Result};
 use serde::{Deserialize, Serialize};
-use tracing::Metadata;
-use tracing_error::SpanTrace;
 
 /// Install the json_eyre hook globally.
 pub fn install(
     with_default_backtrace: bool,
-    with_default_spantrace: bool,
+    _with_default_spantrace: bool,
 ) -> Result<()> {
     eyre::set_hook(Box::new(move |_| {
-        Box::new(Handler::new(with_default_backtrace, with_default_spantrace))
+        Box::new(Handler::new(with_default_backtrace))
     }))?;
 
     Ok(())
@@ -45,26 +41,12 @@ impl BacktraceExt for Report {
     }
 }
 
-/// Convenience trait to get the spantrace from an eyre::Report in case json_eyre is installed.
-pub trait SpantraceExt {
-    fn spantrace(&self) -> Option<&SpanTrace>;
-}
-
-impl SpantraceExt for Report {
-    fn spantrace(&self) -> Option<&SpanTrace> {
-        self.handler()
-            .downcast_ref::<Handler>()
-            .and_then(|handler| handler.spantrace.as_ref())
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 struct BacktraceSymbol {
     // Note: None will be serialized as 'null'
     pub function: Option<String>,
     pub file: Option<String>,
     pub line: Option<u32>,
-    pub fields: Option<String>,
 }
 
 impl BacktraceSymbol {
@@ -75,32 +57,6 @@ impl BacktraceSymbol {
                 .filename()
                 .map(|filename| filename.display().to_string()),
             line: symbol.lineno(),
-            fields: None, // Backtraces don't have fields, only spantraces do
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-struct SpanFrame {
-    pub full_name: String,
-    pub file: Option<String>,
-    pub line: Option<u32>,
-    pub fields: Option<String>,
-}
-
-impl SpanFrame {
-    pub fn from_span_info(metadata: &Metadata<'_>, fields: &str) -> Self {
-        let fields = if fields.is_empty() {
-            None
-        } else {
-            Some(fields.to_string())
-        };
-
-        Self {
-            full_name: format!("{}::{}", metadata.target(), metadata.name()),
-            file: metadata.file().map(|file| file.to_string()),
-            line: metadata.line(),
-            fields,
         }
     }
 }
@@ -114,17 +70,12 @@ struct JsonFormatter {
     /// None if backtrace capturing is disabled.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub backtrace: Option<Vec<(u32, BacktraceSymbol)>>,
-    /// The spantrace of the error.
-    /// None if spantrace capturing is disabled.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub spantrace: Option<Vec<(u32, SpanFrame)>>,
 }
 
 impl JsonFormatter {
     pub fn new(
         err: &(dyn std::error::Error + 'static),
         backtrace: Option<&backtrace::Backtrace>,
-        spantrace: Option<&SpanTrace>,
     ) -> Self {
         let error_chain = successors(Some(err), |e| e.source())
             .enumerate()
@@ -142,24 +93,9 @@ impl JsonFormatter {
                 .collect::<Vec<_>>()
         });
 
-        let spantrace = spantrace.map(|st| {
-            let mut spantrace = Vec::new();
-            st.with_spans(|metadata, fields| {
-                spantrace.push(SpanFrame::from_span_info(metadata, fields));
-                true
-            });
-
-            spantrace
-                .iter()
-                .enumerate()
-                .map(|(i, span_frame)| (i as u32, span_frame.clone()))
-                .collect::<Vec<_>>()
-        });
-
         Self {
             error_chain,
             backtrace,
-            spantrace,
         }
     }
 }
@@ -167,14 +103,10 @@ impl JsonFormatter {
 #[derive(Debug)]
 struct Handler {
     backtrace: Option<backtrace::Backtrace>,
-    spantrace: Option<SpanTrace>,
 }
 
 impl Handler {
-    pub fn new(
-        with_default_backtrace: bool,
-        with_default_spantrace: bool,
-    ) -> Self {
+    pub fn new(with_default_backtrace: bool) -> Self {
         let with_backtrace = env::var("RUST_LIB_BACKTRACE")
             .or_else(|_| env::var("RUST_BACKTRACE"))
             .map(|val| val != "0")
@@ -186,20 +118,7 @@ impl Handler {
             None
         };
 
-        let with_spantrace = env::var("RUST_SPANTRACE")
-            .map(|val| val != "0")
-            .unwrap_or(with_default_spantrace);
-
-        let spantrace = if with_spantrace {
-            Some(SpanTrace::capture())
-        } else {
-            None
-        };
-
-        Self {
-            backtrace,
-            spantrace,
-        }
+        Self { backtrace }
     }
 }
 
@@ -209,11 +128,7 @@ impl EyreHandler for Handler {
         error: &(dyn std::error::Error + 'static),
         f: &mut core::fmt::Formatter<'_>,
     ) -> core::fmt::Result {
-        let formatter = JsonFormatter::new(
-            error,
-            self.backtrace.as_ref(),
-            self.spantrace.as_ref(),
-        );
+        let formatter = JsonFormatter::new(error, self.backtrace.as_ref());
         match serde_json::to_string(&formatter) {
             Ok(json) => write!(f, "{}", json),
             Err(formatter_error) => write!(
@@ -234,7 +149,7 @@ mod tests {
             .context("context 0")
             .context("context 1");
 
-        let formatter = JsonFormatter::new(error.as_ref(), None, None);
+        let formatter = JsonFormatter::new(error.as_ref(), None);
 
         assert_eq!(
             formatter.error_chain,
@@ -258,8 +173,7 @@ mod tests {
 
         let backtrace = backtrace::Backtrace::new();
 
-        let formatter =
-            JsonFormatter::new(error.as_ref(), Some(&backtrace), None);
+        let formatter = JsonFormatter::new(error.as_ref(), Some(&backtrace));
 
         let json = serde_json::to_string(&formatter).unwrap();
 
@@ -331,134 +245,5 @@ mod tests {
                 i
             );
         }
-    }
-
-    #[test]
-    fn test_formatter_with_spantrace() {
-        use tracing_error::{ErrorLayer, SpanTraceStatus};
-        use tracing_subscriber::prelude::*;
-
-        // Install subscriber with ErrorLayer - required for SpanTrace to capture
-        let subscriber =
-            tracing_subscriber::registry().with(ErrorLayer::default());
-        let _guard = tracing::subscriber::set_default(subscriber);
-
-        // Create nested spans with fields
-        let outer_span =
-            tracing::info_span!("outer_span", user_id = 42, action = "test");
-        let _outer_enter = outer_span.enter();
-
-        let inner_span =
-            tracing::info_span!("inner_span", request_id = "abc-123");
-        let _inner_enter = inner_span.enter();
-
-        let spantrace = SpanTrace::capture();
-        assert_eq!(
-            spantrace.status(),
-            SpanTraceStatus::CAPTURED,
-            "SpanTrace should be captured"
-        );
-
-        let error = anyhow::anyhow!("test error");
-        let formatter =
-            JsonFormatter::new(error.as_ref(), None, Some(&spantrace));
-
-        let json = serde_json::to_string(&formatter).unwrap();
-
-        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
-
-        let mut original_spans = Vec::new();
-        spantrace.with_spans(|metadata, fields| {
-            original_spans.push((metadata, fields.to_string()));
-            true
-        });
-
-        // Verify spantrace array exists and has correct length
-        let json_spantrace = parsed["spantrace"]
-            .as_array()
-            .expect("spantrace should be an array");
-        assert_eq!(
-            json_spantrace.len(),
-            original_spans.len(),
-            "Spantrace span count mismatch: JSON has {}, original has {}",
-            json_spantrace.len(),
-            original_spans.len()
-        );
-
-        // Verify each span frame matches
-        for (i, ((metadata, fields), json_entry)) in
-            original_spans.iter().zip(json_spantrace.iter()).enumerate()
-        {
-            // JSON structure is [index, {full_name, file, line, fields}]
-            let json_idx = json_entry[0].as_u64().unwrap() as usize;
-            let json_frame = &json_entry[1];
-
-            assert_eq!(json_idx, i, "Span index mismatch at position {}", i);
-
-            // Compare full_name (target::name)
-            let expected_full_name =
-                format!("{}::{}", metadata.target(), metadata.name());
-            let json_full_name = json_frame["full_name"].as_str().unwrap();
-            assert_eq!(
-                json_full_name, expected_full_name,
-                "Full name mismatch at span {}",
-                i
-            );
-
-            // Compare file
-            let expected_file = metadata.file().map(|s| s.to_string());
-            let json_file = json_frame["file"].as_str().map(|s| s.to_string());
-            assert_eq!(json_file, expected_file, "File mismatch at span {}", i);
-
-            // Compare line (should be present for spans created with macros)
-            let expected_line = metadata.line();
-            let json_line = json_frame["line"].as_u64().map(|l| l as u32);
-            assert_eq!(json_line, expected_line, "Line mismatch at span {}", i);
-
-            // Compare fields
-            let expected_fields = if fields.is_empty() {
-                None
-            } else {
-                Some(fields.clone())
-            };
-            let json_fields =
-                json_frame["fields"].as_str().map(|s| s.to_string());
-            assert_eq!(
-                json_fields, expected_fields,
-                "Fields mismatch at span {}",
-                i
-            );
-        }
-
-        // Inner span should be first (most recent)
-        let first_span = &json_spantrace[0][1];
-        assert!(
-            first_span["full_name"]
-                .as_str()
-                .unwrap()
-                .contains("inner_span"),
-            "First span should be inner_span"
-        );
-        assert!(
-            first_span["fields"]
-                .as_str()
-                .unwrap()
-                .contains("request_id"),
-            "Inner span should have request_id field"
-        );
-
-        // Outer span should be second
-        let second_span = &json_spantrace[1][1];
-        assert!(
-            second_span["full_name"]
-                .as_str()
-                .unwrap()
-                .contains("outer_span"),
-            "Second span should be outer_span"
-        );
-        assert!(
-            second_span["fields"].as_str().unwrap().contains("user_id"),
-            "Outer span should have user_id field"
-        );
     }
 }

--- a/src/eyre/mod.rs
+++ b/src/eyre/mod.rs
@@ -5,13 +5,12 @@
 //!
 //! # Environment Variables
 //!
-//! Backtrace/spantrace capture can be controlled via environment variables.
-//! If set, they override the `with_default_*` config flags:
+//! Backtrace capture can be controlled via environment variables.
+//! If set, they override the `with_default_backtrace` config flag:
 //!
 //! | Feature   | Env Var                                  | Enabled     | Disabled |
 //! |-----------|------------------------------------------|-------------|----------|
 //! | Backtrace | `RUST_LIB_BACKTRACE` or `RUST_BACKTRACE` | any (not 0) | `0`      |
-//! | Spantrace | `RUST_SPANTRACE`                         | any (not 0) | `0`      |
 
 pub mod json_eyre;
 

--- a/src/tracing/datadog.rs
+++ b/src/tracing/datadog.rs
@@ -3,7 +3,6 @@
 use crate::config::LogFormat;
 use crate::tracing::layers::datadog::datadog_layer;
 use opentelemetry_datadog::DatadogPropagator;
-use tracing_error::ErrorLayer;
 use tracing_subscriber::{
     EnvFilter, Layer, layer::SubscriberExt, util::SubscriberInitExt,
 };
@@ -28,10 +27,7 @@ pub(crate) fn init(
     let (dd_layer, provider) =
         datadog_layer(service_name, endpoint, log_format);
     let layers = EnvFilter::new(log_level).and_then(dd_layer);
-    tracing_subscriber::registry()
-        .with(layers)
-        .with(ErrorLayer::default())
-        .init();
+    tracing_subscriber::registry().with(layers).init();
 
     TracingShutdownHandle::new(provider)
 }

--- a/src/tracing/stdout.rs
+++ b/src/tracing/stdout.rs
@@ -2,7 +2,6 @@
 
 use crate::config::LogFormat;
 use crate::tracing::TracingShutdownHandle;
-use tracing_error::ErrorLayer;
 use tracing_subscriber::{
     EnvFilter, Layer, fmt, layer::SubscriberExt, util::SubscriberInitExt,
 };
@@ -26,10 +25,7 @@ pub(crate) fn init(
                 .with_line_number(true)
                 .with_file(true)
                 .with_filter(filter);
-            tracing_subscriber::registry()
-                .with(layer)
-                .with(ErrorLayer::default())
-                .init();
+            tracing_subscriber::registry().with(layer).init();
         }
         LogFormat::Json | LogFormat::DatadogJson => {
             // DatadogJson without the Datadog backend falls back to standard JSON
@@ -38,20 +34,14 @@ pub(crate) fn init(
                 .with_writer(std::io::stdout)
                 .json()
                 .with_filter(filter);
-            tracing_subscriber::registry()
-                .with(layer)
-                .with(ErrorLayer::default())
-                .init();
+            tracing_subscriber::registry().with(layer).init();
         }
         LogFormat::Compact => {
             let layer = fmt::layer()
                 .with_writer(std::io::stdout)
                 .compact()
                 .with_filter(filter);
-            tracing_subscriber::registry()
-                .with(layer)
-                .with(ErrorLayer::default())
-                .init();
+            tracing_subscriber::registry().with(layer).init();
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

tracing-error 0.2's ErrorLayer has a span-lifecycle race condition under concurrent load that panics with "tried to clone a span that already closed". When this fires inside color-eyre's 
  panic handler (which captures a SpanTrace), it triggers a double-panic that aborts the process — crashing production pods ~27/hr.   

## Solution

Remove tracing-error entirely. Strip ErrorLayer::default() from the subscriber stacks in datadog.rs and stdout.rs, and remove all SpanTrace-related code from json_eyre.rs. The install()
  signature is preserved so downstream callers don't break. color-eyre and eyre remain — SpanTrace capture simply becomes a no-op without the ErrorLayer.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
