### PR TITLE
Tracing fixes & improvements + integration test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telemetry-batteries"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "Batteries included library to configure tracing, logs and metrics"
 license = "MIT OR (Apache-2.0 WITH LLVM-exception)"
@@ -40,7 +40,9 @@ tower = "0.5"
 tracing = "0.1"
 tracing-appender = "0.2"
 tracing-opentelemetry = "0.32"
-tracing-opentelemetry-instrumentation-sdk = { version = "0.32", features = ["http"] }
+tracing-opentelemetry-instrumentation-sdk = { version = "0.32", features = [
+  "http",
+] }
 tracing-serde = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 rand = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tower = "0.5"
 tracing = "0.1"
 tracing-appender = "0.2"
 tracing-opentelemetry = "0.32"
+tracing-opentelemetry-instrumentation-sdk = { version = "0.32", features = ["http"] }
 tracing-serde = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 rand = "0.9"

--- a/deny.toml
+++ b/deny.toml
@@ -2,10 +2,6 @@
 # Cargo deny will check dependencies via `--all-features`
 all-features = true
 
-[advisories]
-version = 2
-ignore = ["RUSTSEC-2024-0436"]
-
 [sources]
 unknown-registry = "deny"
 
@@ -17,21 +13,18 @@ confidence-threshold = 1.0
 # List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 allow = [
-    "0BSD",
-    "Apache-2.0 WITH LLVM-exception",
-    "Apache-2.0",
-    "BSD-2-Clause",
-    "BSD-2-Clause-Patent",
-    "BSD-3-Clause",
-    "BSL-1.0",
-    "CC0-1.0",
-    "CDLA-Permissive-2.0",
-    "ISC",
-    "MIT",
-    "MPL-2.0",                        # Although this is copyleft, it is scoped to modifying the original files
-    "OpenSSL",
-    "Unicode-DFS-2016",
-    "Unlicense",
-    "Zlib",
-    "Unicode-3.0",
+  "0BSD",
+  "Apache-2.0 WITH LLVM-exception",
+  "Apache-2.0",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "BSL-1.0",
+  "CC0-1.0",
+  "ISC",
+  "MIT",
+  "MPL-2.0",                        # Although this is copyleft, it is scoped to modifying the original files
+  "Unlicense",
+  "Zlib",
+  "Unicode-3.0",
 ]
+

--- a/examples/axum_tracing.rs
+++ b/examples/axum_tracing.rs
@@ -16,7 +16,10 @@
 //! curl http://localhost:3000/
 //!
 //! # Request with trace context (simulating upstream service)
-//! curl -H "traceparent: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01" \
+//! curl \
+//! -H "x-datadog-trace-id: 7690679301650107577" \
+//! -H "x-datadog-parent-id: 16133904967205640245" \
+//! -H "traceparent: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01" \
 //!      http://localhost:3000/
 //! ```
 

--- a/src/tracing/datadog.rs
+++ b/src/tracing/datadog.rs
@@ -1,11 +1,9 @@
 //! Datadog tracing initialization.
 
 use crate::config::LogFormat;
-use crate::tracing::layers::datadog::datadog_layer;
+use crate::tracing::layers::datadog::datadog_layer_with_log_filter;
 use opentelemetry_datadog::DatadogPropagator;
-use tracing_subscriber::{
-    EnvFilter, Layer, layer::SubscriberExt, util::SubscriberInitExt,
-};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 use super::TracingShutdownHandle;
 
@@ -24,10 +22,13 @@ pub(crate) fn init(
 
     let endpoint = endpoint.unwrap_or(DEFAULT_DATADOG_AGENT_ENDPOINT);
 
-    let (dd_layer, provider) =
-        datadog_layer(service_name, endpoint, log_format);
-    let layers = EnvFilter::new(log_level).and_then(dd_layer);
-    tracing_subscriber::registry().with(layers).init();
+    let (dd_layer, provider) = datadog_layer_with_log_filter(
+        service_name,
+        endpoint,
+        log_format,
+        log_level,
+    );
+    tracing_subscriber::registry().with(dd_layer).init();
 
     TracingShutdownHandle::new(provider)
 }

--- a/src/tracing/layers/datadog.rs
+++ b/src/tracing/layers/datadog.rs
@@ -17,7 +17,7 @@ use tracing_subscriber::fmt::{
     FmtContext, FormatEvent, FormatFields, FormattedFields,
 };
 use tracing_subscriber::registry::LookupSpan;
-use tracing_subscriber::{Layer, fmt};
+use tracing_subscriber::{EnvFilter, Layer, fmt};
 
 use crate::config::LogFormat;
 use crate::tracing::id_generator::ReducedIdGenerator;
@@ -33,6 +33,39 @@ pub fn datadog_layer<S>(
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
 {
+    let provider = datadog_provider(service_name, endpoint);
+    // Use a static string for the tracer name since provider.tracer() requires 'static
+    let tracer = provider.tracer("telemetry-batteries");
+    let otel_layer = tracing_opentelemetry::OpenTelemetryLayer::new(tracer);
+    let format_layer = datadog_format_layer(log_format);
+
+    (format_layer.and_then(otel_layer), provider)
+}
+
+/// Create a Datadog layer where `log_level` filters only log output.
+///
+/// OpenTelemetry span export remains unfiltered so low-level spans can still
+/// be propagated/exported even when logs default to `info`.
+pub fn datadog_layer_with_log_filter<S>(
+    service_name: &str,
+    endpoint: &str,
+    log_format: LogFormat,
+    log_level: &str,
+) -> (impl Layer<S>, SdkTracerProvider)
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    let provider = datadog_provider(service_name, endpoint);
+    // Use a static string for the tracer name since provider.tracer() requires 'static
+    let tracer = provider.tracer("telemetry-batteries");
+    let otel_layer = tracing_opentelemetry::OpenTelemetryLayer::new(tracer);
+    let format_layer =
+        datadog_format_layer(log_format).with_filter(EnvFilter::new(log_level));
+
+    (format_layer.and_then(otel_layer), provider)
+}
+
+fn datadog_provider(service_name: &str, endpoint: &str) -> SdkTracerProvider {
     // Small hack https://github.com/will-bank/datadog-tracing/blob/30cdfba8d00caa04f6ac8e304f76403a5eb97129/src/tracer.rs#L29
     // Until https://github.com/open-telemetry/opentelemetry-rust-contrib/issues/7 is resolved
     // seems to prevent client reuse and avoid the errors in question
@@ -87,12 +120,7 @@ where
     // Set as global tracer provider
     opentelemetry::global::set_tracer_provider(provider.clone());
 
-    // Use a static string for the tracer name since provider.tracer() requires 'static
-    let tracer = provider.tracer("telemetry-batteries");
-    let otel_layer = tracing_opentelemetry::OpenTelemetryLayer::new(tracer);
-    let format_layer = datadog_format_layer(log_format);
-
-    (format_layer.and_then(otel_layer), provider)
+    provider
 }
 
 /// Create a format layer for Datadog.

--- a/src/tracing/middleware.rs
+++ b/src/tracing/middleware.rs
@@ -10,8 +10,7 @@ use std::task::{Context, Poll};
 use http::{Request, Response};
 use tower::{Layer, Service};
 use tracing::{Instrument, Span, info_span};
-
-use super::{trace_from_headers, trace_to_headers};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 /// Function type for creating custom spans.
 pub type MakeSpan = fn(&http::Request<()>) -> Span;
@@ -131,7 +130,7 @@ where
     fn call(&mut self, request: Request<ReqBody>) -> Self::Future {
         // Clone to satisfy borrow checker for the async block
         let inner = self.inner.clone();
-        let inner = std::mem::replace(&mut self.inner, inner);
+        let mut inner = std::mem::replace(&mut self.inner, inner);
 
         // Create a temporary request view for span creation (avoids body type issues)
         let span_request = http::Request::builder()
@@ -141,21 +140,14 @@ where
             .expect("request builder with () body cannot fail");
 
         let span = (self.make_span)(&span_request);
+        let _ = span.set_parent(
+            opentelemetry::global::get_text_map_propagator(|propagator| {
+                propagator.extract(&opentelemetry_http::HeaderExtractor(
+                    request.headers(),
+                ))
+            }),
+        );
 
-        Box::pin(
-            async move {
-                // Extract trace context from incoming headers and attach to current span
-                trace_from_headers(request.headers());
-
-                let mut inner = inner;
-                let mut response = inner.call(request).await?;
-
-                // Inject trace context into response headers
-                trace_to_headers(response.headers_mut());
-
-                Ok(response)
-            }
-            .instrument(span),
-        )
+        Box::pin(async move { inner.call(request).await }.instrument(span))
     }
 }

--- a/src/tracing/middleware.rs
+++ b/src/tracing/middleware.rs
@@ -76,10 +76,7 @@ pub fn make_span_from_request<B>(req: &http::Request<B>) -> Span {
 
 /// Record the response status code on the span and mark 5xx responses as
 /// errored for OpenTelemetry / Datadog.
-pub fn update_span_from_response<B>(
-    span: &Span,
-    response: &http::Response<B>,
-) {
+pub fn update_span_from_response<B>(span: &Span, response: &http::Response<B>) {
     let status = response.status();
     span.record("http.response.status_code", status.as_u16());
     span.record("http.status_code", status.as_u16());

--- a/src/tracing/middleware.rs
+++ b/src/tracing/middleware.rs
@@ -2,26 +2,117 @@
 //!
 //! Provides a [`TraceLayer`] that automatically extracts trace context from
 //! incoming request headers and injects it into outgoing response headers.
+//!
+//! This module also exposes a set of small helpers that match the conventions
+//! used by `will-bank/datadog-tracing`:
+//!
+//! - [`make_span_from_request`] — build a richly-tagged server span from an
+//!   `http::Request`, populating the standard OpenTelemetry `http.*`,
+//!   `url.*`, `network.*`, `server.*`, `user_agent.*` and Datadog
+//!   compatibility fields up-front.
+//! - [`update_span_from_response`] — record the response status code and
+//!   set `otel.status_code = ERROR` on 5xx responses.
+//! - [`update_span_from_error`] — record `otel.status_code = ERROR` and the
+//!   error's message under `exception.message`.
+//! - [`update_span_from_response_or_error`] — convenience dispatcher used
+//!   when wrapping a fallible handler.
 
+use std::error::Error;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use http::{Request, Response};
 use tower::{Layer, Service};
-use tracing::{Instrument, Span, info_span};
+use tracing::field::Empty;
+use tracing::{Instrument, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
+use tracing_opentelemetry_instrumentation_sdk::TRACING_TARGET;
+use tracing_opentelemetry_instrumentation_sdk::http::{
+    http_flavor, http_host, url_scheme, user_agent,
+};
 
 /// Function type for creating custom spans.
 pub type MakeSpan = fn(&http::Request<()>) -> Span;
 
-fn default_make_span(request: &http::Request<()>) -> Span {
-    info_span!(
-        "request",
-        http.method = %request.method(),
-        http.path = %request.uri().path(),
-        http.query = ?request.uri().query(),
+/// Build a richly-tagged server span for an HTTP request.
+///
+/// The set of fields mirrors the conventions used by
+/// `will-bank/datadog-tracing` and includes the standard OpenTelemetry
+/// `http.*`/`url.*`/`network.*`/`server.*`/`user_agent.*` attributes
+/// alongside Datadog-specific aliases (`http.status_code`, `span.type`).
+///
+/// Fields that are only known once the response is produced (status code,
+/// route, client address, trace/request ids, exception message) are declared
+/// as [`tracing::field::Empty`] so they can be populated later via
+/// [`update_span_from_response`] / [`update_span_from_error`].
+pub fn make_span_from_request<B>(req: &http::Request<B>) -> Span {
+    let http_method = req.method();
+    tracing::trace_span!(
+        target: TRACING_TARGET,
+        "HTTP request",
+        http.request.method = %http_method,
+        http.route = Empty,
+        network.protocol.version = %http_flavor(req.version()),
+        server.address = http_host(req),
+        http.client.address = Empty,
+        user_agent.original = user_agent(req),
+        http.response.status_code = Empty,
+        // Datadog alias kept alongside the OTel-native field.
+        http.status_code = Empty,
+        url.path = req.uri().path(),
+        url.query = req.uri().query(),
+        url.scheme = url_scheme(req.uri()),
+        otel.name = %http_method,
+        otel.kind = ?opentelemetry::trace::SpanKind::Server,
+        otel.status_code = Empty,
+        trace_id = Empty,
+        request_id = Empty,
+        exception.message = Empty,
+        // Datadog-specific, non-standard OTel.
+        "span.type" = "web",
     )
+}
+
+/// Record the response status code on the span and mark 5xx responses as
+/// errored for OpenTelemetry / Datadog.
+pub fn update_span_from_response<B>(
+    span: &Span,
+    response: &http::Response<B>,
+) {
+    let status = response.status();
+    span.record("http.response.status_code", status.as_u16());
+    span.record("http.status_code", status.as_u16());
+    if status.is_server_error() {
+        span.record("otel.status_code", "ERROR");
+    }
+}
+
+/// Record an error on the span: sets `otel.status_code = ERROR` and copies
+/// the error's `Display` representation into `exception.message`. If the
+/// error chains a source it is recorded as well.
+pub fn update_span_from_error<E: Error>(span: &Span, error: &E) {
+    span.record("otel.status_code", "ERROR");
+    span.record("exception.message", error.to_string());
+    if let Some(source) = error.source() {
+        span.record("exception.message", source.to_string());
+    }
+}
+
+/// Dispatch helper that updates the span from either a successful response
+/// or an error.
+pub fn update_span_from_response_or_error<B, E: Error>(
+    span: &Span,
+    result: &Result<http::Response<B>, E>,
+) {
+    match result {
+        Ok(response) => update_span_from_response(span, response),
+        Err(error) => update_span_from_error(span, error),
+    }
+}
+
+fn default_make_span(request: &http::Request<()>) -> Span {
+    make_span_from_request(request)
 }
 
 /// Tower layer that propagates distributed trace context.
@@ -132,10 +223,17 @@ where
         let inner = self.inner.clone();
         let mut inner = std::mem::replace(&mut self.inner, inner);
 
-        // Create a temporary request view for span creation (avoids body type issues)
-        let span_request = http::Request::builder()
+        // Build a body-erased view of the request for span creation. We
+        // copy the headers across so helpers like `http_host` and
+        // `user_agent` can populate the span correctly.
+        let mut span_request_builder = http::Request::builder()
             .method(request.method().clone())
             .uri(request.uri().clone())
+            .version(request.version());
+        if let Some(headers) = span_request_builder.headers_mut() {
+            *headers = request.headers().clone();
+        }
+        let span_request = span_request_builder
             .body(())
             .expect("request builder with () body cannot fail");
 
@@ -148,6 +246,16 @@ where
             }),
         );
 
-        Box::pin(async move { inner.call(request).await }.instrument(span))
+        let span_for_response = span.clone();
+        Box::pin(
+            async move {
+                let result = inner.call(request).await;
+                if let Ok(ref response) = result {
+                    update_span_from_response(&span_for_response, response);
+                }
+                result
+            }
+            .instrument(span),
+        )
     }
 }

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -45,20 +45,6 @@ impl Drop for TracingShutdownHandle {
     }
 }
 
-pub fn trace_from_headers(headers: &http::HeaderMap) {
-    let current_span = tracing::Span::current();
-
-    println!("before:current_span = {current_span:?}");
-
-    let _ = current_span.set_parent(
-        opentelemetry::global::get_text_map_propagator(|propagator| {
-            propagator.extract(&opentelemetry_http::HeaderExtractor(headers))
-        }),
-    );
-
-    println!("after:current_span = {current_span:?}");
-}
-
 pub fn trace_to_headers(headers: &mut http::HeaderMap) {
     opentelemetry::global::get_text_map_propagator(|propagator| {
         propagator.inject_context(

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -8,8 +8,7 @@ use opentelemetry::Context;
 use opentelemetry::trace::{SpanContext, SpanId, TraceContextExt, TraceId};
 pub(crate) use opentelemetry_sdk::trace::SdkTracerProvider;
 
-use std::path::PathBuf;
-use std::{fs, io};
+use std::io;
 use tracing::Subscriber;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use tracing_opentelemetry::OtelData;

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -144,26 +144,3 @@ impl io::Write for WriteAdapter<'_> {
         Ok(())
     }
 }
-
-/// Platform agnostic function to get the path to the log directory. If the directory does not
-/// exist, it will be created.
-///
-/// # Returns
-/// * `Ok(PathBuf)` containing the path to the `.logs` directory in the user's home directory.
-/// * `Err(io::Error)` if the home directory cannot be determined, or the `.logs` directory
-///   cannot be created.
-///
-/// # Errors
-/// This function will return an `Err` if the home directory cannot be found or the `.logs`
-/// directory cannot be created. It does not guarantee that the `.logs` directory is writable.
-pub fn get_log_directory() -> Result<PathBuf, io::Error> {
-    let home_dir = dirs::home_dir().ok_or(io::ErrorKind::NotFound)?;
-    let log_dir = home_dir.join(".logs");
-
-    // Create the `.logs` directory if it does not exist
-    if !log_dir.exists() {
-        fs::create_dir_all(&log_dir)?;
-    }
-
-    Ok(log_dir)
-}

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -46,11 +46,17 @@ impl Drop for TracingShutdownHandle {
 }
 
 pub fn trace_from_headers(headers: &http::HeaderMap) {
-    let _ = tracing::Span::current().set_parent(
+    let current_span = tracing::Span::current();
+
+    println!("before:current_span = {current_span:?}");
+
+    let _ = current_span.set_parent(
         opentelemetry::global::get_text_map_propagator(|propagator| {
             propagator.extract(&opentelemetry_http::HeaderExtractor(headers))
         }),
     );
+
+    println!("after:current_span = {current_span:?}");
 }
 
 pub fn trace_to_headers(headers: &mut http::HeaderMap) {

--- a/tests/datadog_integration.rs
+++ b/tests/datadog_integration.rs
@@ -41,7 +41,8 @@ async fn datadog_integration() -> eyre::Result<()> {
 
     let app = Router::new()
         .route("/trace", get(trace_ids))
-        .layer(TraceLayer::new());
+        .layer(TraceLayer::new())
+        .route("/no-trace", get(trace_ids));
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
     let addr = listener.local_addr()?;
@@ -64,15 +65,32 @@ async fn datadog_integration() -> eyre::Result<()> {
         .error_for_status()?
         .text()
         .await?;
-    let response: TraceIds = serde_json::from_str(&body)?;
 
-    let _ = shutdown_tx.send(());
-    server.await??;
+    let response: TraceIds = serde_json::from_str(&body)?;
 
     assert_eq!(response.trace_id, TRACE_ID.to_string());
     // The incoming span id becomes the request span's parent; the request span
     // itself gets a new span id.
     assert_ne!(response.span_id, PARENT_SPAN_ID.to_string());
+
+    let body = reqwest::Client::new()
+        .get(format!("http://{addr}/no-trace"))
+        .header("x-datadog-trace-id", TRACE_ID.to_string())
+        .header("x-datadog-parent-id", PARENT_SPAN_ID.to_string())
+        .header("x-datadog-sampling-priority", "1")
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+    let response: TraceIds = serde_json::from_str(&body)?;
+
+    // no traces or span because TraceLayer is not applied
+    assert_eq!(response.trace_id, "0");
+    assert_eq!(response.span_id, "0");
+
+    let _ = shutdown_tx.send(());
+    server.await??;
 
     Ok(())
 }

--- a/tests/datadog_integration.rs
+++ b/tests/datadog_integration.rs
@@ -1,0 +1,128 @@
+use axum::{Json, Router, routing::get};
+use opentelemetry::trace::{SpanId, TraceId, TracerProvider};
+use opentelemetry_datadog::DatadogPropagator;
+use opentelemetry_sdk::{
+    error::OTelSdkResult,
+    trace::{SdkTracerProvider, SpanData, SpanExporter},
+};
+use std::sync::{Arc, Mutex};
+use telemetry_batteries::tracing::middleware::TraceLayer;
+use tokio::sync::oneshot;
+use tracing_subscriber::prelude::*;
+
+const TRACE_ID: u64 = 7_690_679_301_650_107_577;
+const SPAN_ID: u64 = 16_133_904_967_205_640_245;
+const REQUEST_SPAN_NAME: &str = "datadog_integration_request";
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+struct TraceIds {
+    trace_id: String,
+    span_id: String,
+}
+
+#[derive(Clone, Debug, Default)]
+struct RecordingExporter {
+    spans: Arc<Mutex<Vec<SpanData>>>,
+}
+
+impl RecordingExporter {
+    fn spans(&self) -> Vec<SpanData> {
+        self.spans.lock().unwrap().clone()
+    }
+}
+
+impl SpanExporter for RecordingExporter {
+    async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+        self.spans.lock().unwrap().extend(batch);
+        Ok(())
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn datadog_integration() -> eyre::Result<()> {
+    opentelemetry::global::set_text_map_propagator(DatadogPropagator::new());
+
+    let exporter = RecordingExporter::default();
+    let provider = SdkTracerProvider::builder()
+        .with_simple_exporter(exporter.clone())
+        .build();
+    let tracer = provider.tracer("datadog-integration-test");
+    let otel_layer =
+        telemetry_batteries::tracing_opentelemetry::OpenTelemetryLayer::new(
+            tracer,
+        );
+    let subscriber = tracing_subscriber::registry().with(otel_layer);
+    let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+
+    let app = Router::new()
+        .route("/trace", get(trace_ids))
+        .layer(TraceLayer::new().with_make_span(make_span));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+    });
+
+    let body = reqwest::Client::new()
+        .get(format!("http://{addr}/trace"))
+        .header("x-datadog-trace-id", TRACE_ID.to_string())
+        .header("x-datadog-parent-id", SPAN_ID.to_string())
+        .header("x-datadog-sampling-priority", "1")
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+    let response: TraceIds = serde_json::from_str(&body)?;
+
+    let _ = shutdown_tx.send(());
+    server.await??;
+
+    provider.force_flush()?;
+    let spans = exporter.spans();
+    let request_span = spans
+        .iter()
+        .find(|span| span.name.as_ref() == REQUEST_SPAN_NAME)
+        .expect("request span was not exported");
+
+    assert_eq!(response.trace_id, TRACE_ID.to_string());
+    assert_eq!(
+        response.span_id,
+        span_id_to_u64(request_span.span_context.span_id()).to_string()
+    );
+    assert_eq!(
+        trace_id_to_u128(request_span.span_context.trace_id()),
+        TRACE_ID as u128
+    );
+    assert_eq!(span_id_to_u64(request_span.parent_span_id), SPAN_ID);
+    assert!(request_span.parent_span_is_remote);
+
+    Ok(())
+}
+
+async fn trace_ids() -> Json<TraceIds> {
+    let (trace_id, span_id) = telemetry_batteries::tracing::extract_span_ids();
+
+    Json(TraceIds {
+        trace_id: trace_id_to_u128(trace_id).to_string(),
+        span_id: span_id_to_u64(span_id).to_string(),
+    })
+}
+
+fn make_span(_: &http::Request<()>) -> tracing::Span {
+    tracing::info_span!("datadog_integration_request")
+}
+
+fn trace_id_to_u128(trace_id: TraceId) -> u128 {
+    u128::from_be_bytes(trace_id.to_bytes())
+}
+
+fn span_id_to_u64(span_id: SpanId) -> u64 {
+    u64::from_be_bytes(span_id.to_bytes())
+}

--- a/tests/datadog_integration.rs
+++ b/tests/datadog_integration.rs
@@ -33,9 +33,6 @@ async fn datadog_integration() -> eyre::Result<()> {
         preset: TelemetryPreset::Datadog,
         service_name: Some("datadog-integration-test".to_owned()),
         log_format: Some(LogFormat::DatadogJson),
-        // No Datadog agent is needed for this test. Export will fail on shutdown,
-        // but propagation happens before export.
-        datadog_endpoint: Some("http://127.0.0.1:9".to_owned()),
         ..TelemetryConfig::default()
     })?;
 

--- a/tests/datadog_integration.rs
+++ b/tests/datadog_integration.rs
@@ -1,18 +1,25 @@
-use axum::{Json, Router, routing::get};
-use opentelemetry::trace::{SpanId, TraceId, TracerProvider};
-use opentelemetry_datadog::DatadogPropagator;
-use opentelemetry_sdk::{
-    error::OTelSdkResult,
-    trace::{SdkTracerProvider, SpanData, SpanExporter},
-};
+use std::io;
 use std::sync::{Arc, Mutex};
+
+use axum::{Json, Router, routing::get};
+use opentelemetry::Context;
+use opentelemetry::trace::{
+    SpanContext, SpanId, TraceContextExt, TraceFlags, TraceId, TraceState,
+    TracerProvider,
+};
+use telemetry_batteries::tracing::layers::datadog::DatadogFormat;
 use telemetry_batteries::tracing::middleware::TraceLayer;
+use telemetry_batteries::tracing_opentelemetry::OpenTelemetrySpanExt;
+use telemetry_batteries::{
+    LogFormat, TelemetryConfig, TelemetryPreset, init_with_config,
+};
 use tokio::sync::oneshot;
+use tracing_subscriber::Layer;
+use tracing_subscriber::fmt::MakeWriter;
 use tracing_subscriber::prelude::*;
 
 const TRACE_ID: u64 = 7_690_679_301_650_107_577;
-const SPAN_ID: u64 = 16_133_904_967_205_640_245;
-const REQUEST_SPAN_NAME: &str = "datadog_integration_request";
+const PARENT_SPAN_ID: u64 = 16_133_904_967_205_640_245;
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 struct TraceIds {
@@ -20,43 +27,21 @@ struct TraceIds {
     span_id: String,
 }
 
-#[derive(Clone, Debug, Default)]
-struct RecordingExporter {
-    spans: Arc<Mutex<Vec<SpanData>>>,
-}
-
-impl RecordingExporter {
-    fn spans(&self) -> Vec<SpanData> {
-        self.spans.lock().unwrap().clone()
-    }
-}
-
-impl SpanExporter for RecordingExporter {
-    async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
-        self.spans.lock().unwrap().extend(batch);
-        Ok(())
-    }
-}
-
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn datadog_integration() -> eyre::Result<()> {
-    opentelemetry::global::set_text_map_propagator(DatadogPropagator::new());
-
-    let exporter = RecordingExporter::default();
-    let provider = SdkTracerProvider::builder()
-        .with_simple_exporter(exporter.clone())
-        .build();
-    let tracer = provider.tracer("datadog-integration-test");
-    let otel_layer =
-        telemetry_batteries::tracing_opentelemetry::OpenTelemetryLayer::new(
-            tracer,
-        );
-    let subscriber = tracing_subscriber::registry().with(otel_layer);
-    let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+    let _guard = init_with_config(TelemetryConfig {
+        preset: TelemetryPreset::Datadog,
+        service_name: Some("datadog-integration-test".to_owned()),
+        log_format: Some(LogFormat::DatadogJson),
+        // No Datadog agent is needed for this test. Export will fail on shutdown,
+        // but propagation happens before export.
+        datadog_endpoint: Some("http://127.0.0.1:9".to_owned()),
+        ..TelemetryConfig::default()
+    })?;
 
     let app = Router::new()
         .route("/trace", get(trace_ids))
-        .layer(TraceLayer::new().with_make_span(make_span));
+        .layer(TraceLayer::new());
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
     let addr = listener.local_addr()?;
@@ -72,7 +57,7 @@ async fn datadog_integration() -> eyre::Result<()> {
     let body = reqwest::Client::new()
         .get(format!("http://{addr}/trace"))
         .header("x-datadog-trace-id", TRACE_ID.to_string())
-        .header("x-datadog-parent-id", SPAN_ID.to_string())
+        .header("x-datadog-parent-id", PARENT_SPAN_ID.to_string())
         .header("x-datadog-sampling-priority", "1")
         .send()
         .await?
@@ -84,29 +69,60 @@ async fn datadog_integration() -> eyre::Result<()> {
     let _ = shutdown_tx.send(());
     server.await??;
 
-    provider.force_flush()?;
-    let spans = exporter.spans();
-    let request_span = spans
-        .iter()
-        .find(|span| span.name.as_ref() == REQUEST_SPAN_NAME)
-        .expect("request span was not exported");
-
     assert_eq!(response.trace_id, TRACE_ID.to_string());
-    assert_eq!(
-        response.span_id,
-        span_id_to_u64(request_span.span_context.span_id()).to_string()
-    );
-    assert_eq!(
-        trace_id_to_u128(request_span.span_context.trace_id()),
-        TRACE_ID as u128
-    );
-    assert_eq!(span_id_to_u64(request_span.parent_span_id), SPAN_ID);
-    assert!(request_span.parent_span_is_remote);
+    // The incoming span id becomes the request span's parent; the request span
+    // itself gets a new span id.
+    assert_ne!(response.span_id, PARENT_SPAN_ID.to_string());
 
     Ok(())
 }
 
+#[test]
+fn datadog_logs_include_current_trace_and_span_ids() {
+    let logs = BufWriter::new();
+    let provider =
+        opentelemetry_sdk::trace::SdkTracerProvider::builder().build();
+    let tracer = provider.tracer("datadog-log-test");
+    let otel_layer =
+        telemetry_batteries::tracing_opentelemetry::OpenTelemetryLayer::new(
+            tracer,
+        );
+    let format_layer = tracing_subscriber::fmt::Layer::new()
+        .json()
+        .event_format(DatadogFormat)
+        .with_writer(logs.clone());
+    let subscriber =
+        tracing_subscriber::registry().with(format_layer.and_then(otel_layer));
+
+    let span_id = tracing::subscriber::with_default(subscriber, || {
+        let span = tracing::info_span!("log_test_span");
+        let parent = SpanContext::new(
+            TraceId::from(TRACE_ID as u128),
+            SpanId::from(PARENT_SPAN_ID),
+            TraceFlags::SAMPLED,
+            true,
+            TraceState::default(),
+        );
+        span.set_parent(Context::new().with_remote_span_context(parent))
+            .unwrap();
+
+        let _entered = span.enter();
+        let (_, span_id) = telemetry_batteries::tracing::extract_span_ids();
+        tracing::info!("inside propagated span");
+        span_id_to_u64(span_id)
+    });
+
+    let log: serde_json::Value = serde_json::from_str(logs.contents().trim())
+        .expect("log line is not valid JSON");
+
+    assert_eq!(log["message"], "inside propagated span");
+    assert_eq!(log["dd.trace_id"], TRACE_ID.to_string());
+    assert_eq!(log["dd.span_id"], span_id.to_string());
+}
+
 async fn trace_ids() -> Json<TraceIds> {
+    tracing::info!("handling trace request");
+
     let (trace_id, span_id) = telemetry_batteries::tracing::extract_span_ids();
 
     Json(TraceIds {
@@ -115,8 +131,36 @@ async fn trace_ids() -> Json<TraceIds> {
     })
 }
 
-fn make_span(_: &http::Request<()>) -> tracing::Span {
-    tracing::info_span!("datadog_integration_request")
+#[derive(Clone)]
+struct BufWriter(Arc<Mutex<Vec<u8>>>);
+
+impl BufWriter {
+    fn new() -> Self {
+        Self(Arc::new(Mutex::new(Vec::new())))
+    }
+
+    fn contents(&self) -> String {
+        String::from_utf8(self.0.lock().unwrap().clone()).unwrap()
+    }
+}
+
+impl io::Write for BufWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for BufWriter {
+    type Writer = BufWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
 }
 
 fn trace_id_to_u128(trace_id: TraceId) -> u128 {


### PR DESCRIPTION
This PR:

1. Fixes the tracing context extraction (along with integration test to ensure it works + an example)
2. Moves tracing filtering to only affect logging not tracing
3. Improves the default make_span to mirror that of will-bank/datadog-tracing - it contains many more useful fields as well as attaches error information on response
4. cleans up a few unused functions
5. fixes deny.toml (a few items are no longer relevant)