### PR TITLE
Improve CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          components: rustfmt
+          components: rustfmt,clippy
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,68 +11,39 @@ env:
 
 jobs:
   test:
-    name: test ${{ matrix.rust }} ${{ matrix.flags }}
+    name: Rust CI - ${{ matrix.rust }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        rust: ["stable"]
-        flags: [""]
+        rust: ["stable", "nightly"]
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
+          components: rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - name: build
+      - name: Build
         run: cargo build
-      - name: test
+      - name: Test
         run: cargo test --workspace
-
-  clippy:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@clippy
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-      - run: cargo clippy --workspace --all-targets --all-features
+      - name: Lint
+        run: cargo clippy --workspace --all-targets --all-features
         env:
           RUSTFLAGS: -Dwarnings
-
-  docs:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly
-      - uses: Swatinem/rust-cache@v2
+      - name: Fmt
+        run: cargo fmt --all --check
+      - name: Licensing
+        uses: EmbarkStudios/cargo-deny-action@v2.0.14
         with:
-          cache-on-failure: true
-      - run: cargo doc --workspace --all-features --no-deps --document-private-items
-        env:
-          RUSTDOCFLAGS: "--cfg docsrs -D warnings"
-
-  fmt:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: rustfmt
-      - run: cargo fmt --all --check
+          command: check licenses sources
 
   cargo-deny:
     name: Licensing and Advisories
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - uses: EmbarkStudios/cargo-deny-action@v2.0.14
-        with:
-          command: check advisories bans licenses sources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,3 @@ jobs:
         uses: EmbarkStudios/cargo-deny-action@v2.0.14
         with:
           command: check licenses sources
-
-  cargo-deny:
-    name: Licensing and Advisories
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6


### PR DESCRIPTION
Improves CI workflow to:

1. Run on both stable & nightly
1. All steps (build, test, lint, fmt, deny) run in a single run using the same checkout & cached data
1. Deny has been reduced to only licenses & sources checks - it doesn't really make sense to check advisories on a lib crate since it's largely based on the contents of Cargo.lock which is not check into the repo
